### PR TITLE
Fix total capacity calculation

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -335,8 +335,8 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
       StatFs rootDir = new StatFs(Environment.getRootDirectory().getAbsolutePath());
       StatFs dataDir = new StatFs(Environment.getDataDirectory().getAbsolutePath());
 
-      BigInteger rootDirCapacity = multiplyBlockCountWithSize(rootDir);
-      BigInteger dataDirCapacity = multiplyBlockCountWithSize(dataDir);
+      BigInteger rootDirCapacity = getDirTotalCapacity(rootDir);
+      BigInteger dataDirCapacity = getDirTotalCapacity(dataDir);
 
       return rootDirCapacity.add(dataDirCapacity);
     } catch (Exception e) {
@@ -346,7 +346,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getTotalDiskCapacity(Promise p) { p.resolve(getTotalDiskCapacitySync()); }
 
-  private BigInteger multiplyBlockCountWithSize(StatFs dir) {
+  private BigInteger getDirTotalCapacity(StatFs dir) {
     return BigInteger.valueOf(dir.getBlockCountLong()).multiply(BigInteger.valueOf(dir.getBlockSizeLong()));
   }
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -346,7 +346,7 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getTotalDiskCapacity(Promise p) { p.resolve(getTotalDiskCapacitySync()); }
 
-  private BigInteger multiplyBlockCountWithSize(dir) {
+  private BigInteger multiplyBlockCountWithSize(StatFs dir) {
     return BigInteger.valueOf(dir.getBlockCountLong()).multiply(BigInteger.valueOf(dir.getBlockSizeLong()));
   }
 

--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -332,14 +332,23 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
   @ReactMethod(isBlockingSynchronousMethod = true)
   public double getTotalDiskCapacitySync() {
     try {
-      StatFs root = new StatFs(Environment.getRootDirectory().getAbsolutePath());
-      return BigInteger.valueOf(root.getBlockCount()).multiply(BigInteger.valueOf(root.getBlockSize())).doubleValue();
+      StatFs rootDir = new StatFs(Environment.getRootDirectory().getAbsolutePath());
+      StatFs dataDir = new StatFs(Environment.getDataDirectory().getAbsolutePath());
+
+      BigInteger rootDirCapacity = multiplyBlockCountWithSize(rootDir);
+      BigInteger dataDirCapacity = multiplyBlockCountWithSize(dataDir);
+
+      return rootDirCapacity.add(dataDirCapacity);
     } catch (Exception e) {
       return -1;
     }
   }
   @ReactMethod
   public void getTotalDiskCapacity(Promise p) { p.resolve(getTotalDiskCapacitySync()); }
+
+  private BigInteger multiplyBlockCountWithSize(dir) {
+    return BigInteger.valueOf(dir.getBlockCountLong()).multiply(BigInteger.valueOf(dir.getBlockSizeLong()));
+  }
 
   @ReactMethod(isBlockingSynchronousMethod = true)
   public double getFreeDiskStorageSync() {


### PR DESCRIPTION
## Description

Fixing issue while getting android total capacity. Sum up root directory and data directory to get total capacity.

Added `getDirTotalCapacity()` private method that avoid code duplication.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I mentioned this change in `CHANGELOG.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
